### PR TITLE
Strick check for defaultlue value

### DIFF
--- a/src/CliArgs/CliArgs.php
+++ b/src/CliArgs/CliArgs.php
@@ -148,7 +148,7 @@ class CliArgs
             $value = $arguments[$cfg['key']];
         } elseif ($this->isFlagExists($cfg['alias'])) {
             $value = $arguments[$cfg['alias']];
-        } elseif ($cfg['default']) {
+        } elseif (isset($cfg['default'])) {
             return $cfg['default'];
         } else {
             return null;


### PR DESCRIPTION
Permit to have default value to false.

It's improving code readibility when an arg can be a flag or a value.

Eg: https://github.com/PiedWeb/LogsAnalyzer/blob/master/bin/analyzer#L52